### PR TITLE
Remove out-of-date business information

### DIFF
--- a/businesses.md
+++ b/businesses.md
@@ -36,9 +36,6 @@ phone: (01382) 552512
 Co-Op  
 Licenced Grocers
 
-Cynicus Picture Framing  
-phone: (01382) 552383
-
 David Beat  
 Plumbing &amp; Heating  
 phone: (01382) 552656


### PR DESCRIPTION
The number for Cynicus framing was reassigned, and no other contact information can be verified.